### PR TITLE
Hotfix/cfdp rates

### DIFF
--- a/sample_defs/tables/to_lab_sub.c
+++ b/sample_defs/tables/to_lab_sub.c
@@ -66,9 +66,9 @@ TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
                                       {CFE_SB_MSGID_WRAP_VALUE(SNTP_HK_TLM_MID), {0, 0}, 4},
 
                                       {CFE_SB_MSGID_WRAP_VALUE(CF_HK_TLM_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH0_OUT_MID), {0, 0}, 10},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH1_OUT_MID), {0, 0}, 10},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH2_OUT_MID), {0, 0}, 10},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH0_OUT_MID), {0, 0}, 64},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH1_OUT_MID), {0, 0}, 64},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH2_OUT_MID), {0, 0}, 64},
 #if 0
         /* Add these if needed */
         {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0,0}, 4},

--- a/sample_defs/tables/to_lab_sub.c
+++ b/sample_defs/tables/to_lab_sub.c
@@ -66,9 +66,9 @@ TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
                                       {CFE_SB_MSGID_WRAP_VALUE(SNTP_HK_TLM_MID), {0, 0}, 4},
 
                                       {CFE_SB_MSGID_WRAP_VALUE(CF_HK_TLM_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH0_OUT_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH1_OUT_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH2_OUT_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH0_OUT_MID), {0, 0}, 10},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH1_OUT_MID), {0, 0}, 10},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CF_CH2_OUT_MID), {0, 0}, 10},
 #if 0
         /* Add these if needed */
         {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0,0}, 4},


### PR DESCRIPTION
Increased rate limits in TO_LAB that caused dropped packets for large CFDP file transfers.

This docker-compose flag is one of 3 changes (including those in brash_docker and cfs repos) to reduce or eliminate dropped packets during large CFDP transfers.